### PR TITLE
Gemfile の参照方法を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.6.6
 
+ENV BUNDLE_GEMFILE /app/Gemfile
+
 WORKDIR /app
 
 COPY Gemfile Gemfile.lock /app/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-bundle exec --gemfile=/app/Gemfile weneedfeed build --base-url="$1" --schema-path="$2"
+bundle exec weneedfeed build --base-url="$1" --schema-path="$2"


### PR DESCRIPTION
GitHub Actions を実行するリポジトリに `Gemfile`, `Gemfile.lock` が含まれている場合、そちらを参照して `bundle exec weneedfeed build` コマンドが実行されてしまうため、これを修正しました。

e.g.) https://github.com/supermomonga/weneedfeed-magcomi/runs/2268044971?check_suite_focus=true

変更内容は以下の通りです

- `bundle exec` への `--gemfile` オプション指定を削除（[bundle exec コマンドのオプション](https://bundler.io/v1.17/man/bundle-exec.1.html)参照）
- `Dockerfile` 内で環境変数 `BUNDLE_GEMFILE` を指定（[bundle config](https://bundler.io/v1.17/man/bundle-config.1.html#LIST-OF-AVAILABLE-KEYS)参照）

この修正でビルドが通ることを確認済みです。

e.g.) https://github.com/supermomonga/weneedfeed-magcomi/runs/2268210612?check_suite_focus=true